### PR TITLE
Update .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: checkov-conda
   name: checkov-conda
   description: 'This hook runs checkov.'
-  entry: checkov -d .
+  entry: checkov -d . --download-external-modules true --quiet
   language: conda
   pass_filenames: false
   always_run: false


### PR DESCRIPTION
Add flags `--download-external-modules true` and  `--quiet` to checkov.

> --download-external-modules
>
> Download external terraform modules from public git repositories and terraform registry
>
> -- quiet

> For the CLI output, display only failed checks. Also disables progress bars.
>
> https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->
